### PR TITLE
Add Python port and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Links: [video demo](https://www.instagram.com/p/C46Qy2LJ8Na/), [live demo](https
 **Mouth Synth** is an interactive audio-visual installation that synthesizes whimsical, surreal sounds in response to a viewer’s facial movements. As the viewer stands before the installation, their head and mouth gestures are captured and processed by a machine-learning-powered program that translates these movements into playful, expressive music.
 
 Viewers are invited to interact, perform, and experiment, making them an integral part of the artwork itself. By centering the mouth as the primary means of interaction, _Mouth Synth_ challenges conventional modes of control, offering a unique and intimate way to shape sound and engage with art.
+
+## Python Port
+
+A ready-to-install Python recreation of the experience lives in [`python_port/`](python_port/). It uses OpenCV, MediaPipe, NumPy, and Pygame to mirror the browser implementation. Read [`docs/python-port-plan.md`](docs/python-port-plan.md) for the architectural overview and [`python_port/README.md`](python_port/README.md) for installation and packaging instructions.

--- a/docs/original-code-overview.md
+++ b/docs/original-code-overview.md
@@ -1,0 +1,35 @@
+# Original JavaScript Project Overview
+
+This document walks through the structure of the existing p5.js + ml5.js project and explains, at a high level, what each script is responsible for. The goal is to give you a commented, holistic view of the original implementation before considering a port to Python.
+
+## Entry Point (`index.html`)
+- Loads p5.js, Tone.js, and ml5.js libraries.
+- Includes the custom helper scripts (`videomanager.js`, `ml5manager.js`, `uimanager.js`, `soundmanager.js`) before finally loading `sketch.js`.
+- Creates a p5.js instance that executes the exported `sketch` function defined in `scripts/sketch.js`.
+
+## `scripts/sketch.js`
+- Configures runtime options for the exhibit, audio synthesis, face tracking, video capture, and UI.
+- Bootstraps the helper managers and wires the lip-motion callbacks to audio synthesis changes.
+- Implements the main p5.js lifecycle (`preload`, `setup`, `draw`, etc.) to update the video feed, draw face landmarks, and render on-canvas UI messaging.
+- Implements exhibit-specific behaviour (auto-reload after prolonged absence).
+
+## `scripts/videomanager.js`
+- Creates a hidden `createCapture` element using p5.js to stream from the webcam.
+- Applies pixelation and color overlay effects before rendering the video texture onto the canvas each frame.
+- Handles responsive scaling, mirroring, and fit/cover logic.
+
+## `scripts/ml5manager.js`
+- Wraps the ml5.js FaceMesh API to detect and track facial landmarks.
+- Smooths landmark motion, determines lip open/close state, and exposes helper functions for lip rotation/opening percentages.
+- Exposes callbacks (`lipsOpened`, `lipsClosed`, `lipsMovedWhileOpen`) that `sketch.js` wires into Tone.js parameter changes.
+
+## `scripts/soundmanager.js`
+- Configures a Tone.js AMSynth with a Chorus effect and waveform analyser.
+- Responds to lip-motion callbacks by starting/stopping notes, detuning, modulating, and adjusting volume.
+- Handles user-gesture requirements for enabling audio in browsers (`mousePressed`).
+
+## `scripts/uimanager.js`
+- Loads fonts, renders status text, and (optionally) the frame-rate display.
+- Provides helper functions to update copy based on loading state and whether a face is currently detected.
+
+With these components combined, the browser experience captures webcam footage, detects lip movements with MediaPipe (via ml5.js), and modulates a synthesizer in real time.

--- a/docs/python-port-plan.md
+++ b/docs/python-port-plan.md
@@ -1,0 +1,43 @@
+# Python Port Technical Plan
+
+This section summarises the technologies required to reproduce the browser experience in Python, discusses complexity trade-offs, and introduces the packaged reference implementation included in this repository.
+
+## Core Technologies Needed
+- **OpenCV (cv2)** – Captures webcam frames and performs image manipulation before rendering.
+- **MediaPipe** – Provides cross-platform FaceMesh landmark detection comparable to ml5.js.
+- **NumPy** – Efficient numerical operations for geometry and smoothing.
+- **Pygame** – Hosts the application window, handles drawing, keyboard/mouse events, and can drive the main loop.
+- **PyGame.midi** or **PyGame.sndarray** – For real-time audio playback; in this sample we drive a simple synthesiser using generated waveforms.
+- **SoundDevice (optional)** – A lower-latency audio backend if you want to bypass Pygame's mixer.
+
+## Complexity Compared to the Browser Version
+- **Manual Event Loop** – Python requires explicit control over frame timing and event polling (handled by the browser/p5.js previously).
+- **Threading/Async** – MediaPipe and OpenCV operate synchronously; keeping UI responsive often means introducing worker threads or buffering.
+- **Audio Stack Differences** – Tone.js exposes high-level synth constructs; recreating this means building or integrating a synthesis layer manually (the included implementation demonstrates a basic FM synth in Python for parity).
+- **Packaging & Distribution** – Unlike the single HTML bundle, Python needs dependency management (via `pip`), platform-specific runtime libraries (e.g., `portaudio`), and possibly virtual environment setup instructions.
+
+Despite these added responsibilities, the Python port keeps concepts parallel to the JavaScript architecture: managers for video, face landmarks, sound, and UI orchestration.
+
+## Included Reference Package
+The repository now includes a `python_port/` directory with an installable package named `mouth-synth`. It mirrors the JavaScript managers:
+
+| JavaScript Module        | Python Counterpart                           |
+|--------------------------|----------------------------------------------|
+| `scripts/videomanager.js`| `mouth_synth/video.py`                        |
+| `scripts/ml5manager.js`  | `mouth_synth/face_tracker.py`                |
+| `scripts/soundmanager.js`| `mouth_synth/sound.py`                        |
+| `scripts/uimanager.js`   | `mouth_synth/ui.py`                           |
+| `scripts/sketch.js`      | `mouth_synth/app.py` (ties everything together)|
+
+### Features
+- A cohesive `MouthSynthApp` class replicates the lip-controlled synthesiser workflow.
+- Configuration mirrors the JS options, loaded from `mouth_synth/config.py` for clarity.
+- Entry-point script `python_port/main.py` runs the app once dependencies are installed.
+- `pyproject.toml` enables packaging and dependency installation via `pip install .`.
+
+### Getting Started
+1. Install system requirements (Python 3.10+, pip, development headers for PortAudio on macOS/Linux).
+2. From the `python_port/` directory run `pip install -e .` to install the package in editable mode.
+3. Execute `python -m mouth_synth` or `python main.py` to launch the experience.
+
+The Python port is more verbose because it recreates browser conveniences manually, but the provided structure keeps it approachable and ready for deployment.

--- a/python_port/README.md
+++ b/python_port/README.md
@@ -1,0 +1,26 @@
+# Mouth Synth (Python Port)
+
+This package recreates the browser-based "Mouth Synth" experience using Python tooling. It captures webcam input with OpenCV, analyses lip landmarks via MediaPipe, and drives a small FM synthesiser implemented with NumPy and Pygame.
+
+## Installation
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+pip install --upgrade pip
+pip install -e .
+```
+
+> **Note**: MediaPipe requires additional system dependencies on some platforms. Consult the [MediaPipe installation guide](https://developers.google.com/mediapipe/solutions/vision/face_landmarker/python) if you encounter build errors.
+
+## Usage
+```bash
+python -m mouth_synth
+```
+
+The program will open a Pygame window, start webcam capture, and play a sustained tone whenever your lips are detected as open. Moving your mouth changes pitch, modulation index, and harmonicity—mirroring the JavaScript original.
+
+## Configuration
+Runtime parameters such as MIDI scale, smoothing factors, and UI colours live in `mouth_synth/config.py`. Override them by creating a Python file and importing the module to mutate the dataclasses prior to launching.
+
+## Packaging
+Running `python -m build` from this directory will produce wheel and sdist archives suitable for distribution. Because OpenCV and MediaPipe ship platform-specific wheels, no extra binary build steps are necessary.

--- a/python_port/main.py
+++ b/python_port/main.py
@@ -1,0 +1,7 @@
+"""Convenience launcher for the Mouth Synth Python port."""
+
+from mouth_synth import AppConfig, MouthSynthApp
+
+
+if __name__ == "__main__":
+    MouthSynthApp(AppConfig()).run()

--- a/python_port/mouth_synth/__init__.py
+++ b/python_port/mouth_synth/__init__.py
@@ -1,0 +1,6 @@
+"""Mouth Synth Python package."""
+
+from .app import MouthSynthApp
+from .config import AppConfig
+
+__all__ = ["MouthSynthApp", "AppConfig"]

--- a/python_port/mouth_synth/__main__.py
+++ b/python_port/mouth_synth/__main__.py
@@ -1,0 +1,13 @@
+"""Command line entry point for the Mouth Synth application."""
+
+from .app import MouthSynthApp
+from .config import AppConfig
+
+
+def main() -> None:
+    app = MouthSynthApp(AppConfig())
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/python_port/mouth_synth/app.py
+++ b/python_port/mouth_synth/app.py
@@ -1,0 +1,109 @@
+"""Main application loop that mirrors the JavaScript sketch."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pygame
+
+from .config import AppConfig
+from .face_tracker import FaceMetrics, FaceTracker
+from .sound import SoundManager
+from .ui import UiManager
+from .video import FrameBundle, VideoManager
+
+
+@dataclass
+class AppState:
+    audio_started: bool = False
+    face_metrics: Optional[FaceMetrics] = None
+    face_detected: bool = False
+    last_face_time: float = 0.0
+
+
+class MouthSynthApp:
+    def __init__(self, config: AppConfig) -> None:
+        self.config = config
+        self.video = VideoManager(config.video)
+        self.face_tracker = FaceTracker(config.ml5)
+        self.sound = SoundManager(config.sound)
+        self.ui = UiManager(config.ui)
+        pygame.init()
+        self.screen = pygame.display.set_mode((config.video.width, config.video.height))
+        pygame.display.set_caption("Mouth Synth (Python)")
+        self.clock = pygame.time.Clock()
+        self.state = AppState()
+
+    def run(self) -> None:
+        try:
+            running = True
+            while running:
+                running = self._handle_events()
+                bundle = self.video.read()
+                metrics = self.face_tracker.process(bundle.frame)
+                self._update_state(metrics)
+                self._update_audio()
+                self._draw(bundle)
+                self.clock.tick(self.config.fps)
+        finally:
+            self._shutdown()
+
+    def _handle_events(self) -> bool:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return False
+            if event.type == pygame.MOUSEBUTTONDOWN:
+                self.state.audio_started = True
+        return True
+
+    def _update_state(self, metrics: Optional[FaceMetrics]) -> None:
+        self.state.face_metrics = metrics
+        self.state.face_detected = metrics is not None
+        if metrics:
+            self.state.last_face_time = time.time()
+        self.ui.update(
+            ready=True,
+            audio_started=self.state.audio_started,
+            face_detected=self.state.face_detected,
+        )
+
+    def _update_audio(self) -> None:
+        metrics = self.state.face_metrics
+        if not self.state.audio_started or metrics is None:
+            self.sound.trigger_end()
+            return
+
+        opening = metrics.lips_opening
+        opening_pct = np.clip(opening / (self.config.ml5.lips_open_threshold * 2), 0.0, 1.0)
+        rotation_pct = np.clip((metrics.lips_rotation + 45) / 90, 0.0, 1.0)
+        heading_x_pct = np.clip((metrics.tip_heading_x + 50) / 100, 0.0, 1.0)
+        heading_y_pct = np.clip((metrics.tip_heading_y + 50) / 100, 0.0, 1.0)
+
+        if opening > self.config.ml5.lips_open_threshold:
+            self.sound.trigger_start(rotation_pct)
+        elif opening < self.config.ml5.lips_close_threshold:
+            self.sound.trigger_end()
+
+        self.sound.change_volume(opening_pct)
+        self.sound.detune(rotation_pct)
+        self.sound.change_effect_frequency(rotation_pct)
+        self.sound.move_harmonicity(heading_x_pct)
+        self.sound.change_modulation_index(heading_y_pct)
+
+    def _draw(self, bundle: FrameBundle) -> None:
+        frame_surface = pygame.surfarray.make_surface(np.rot90(bundle.surface))
+        self.screen.blit(frame_surface, (0, 0))
+        self.ui.draw(self.screen)
+        pygame.display.flip()
+
+    def _shutdown(self) -> None:
+        self.sound.close()
+        self.face_tracker.close()
+        self.video.release()
+        pygame.quit()
+
+
+__all__ = ["MouthSynthApp"]

--- a/python_port/mouth_synth/config.py
+++ b/python_port/mouth_synth/config.py
@@ -1,0 +1,86 @@
+"""Configuration models that mirror the JavaScript options."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+@dataclass
+class ExhibitConfig:
+    reload_total_ms: int = 3_600_000
+    reload_absence_ms: int = 10_000
+
+
+@dataclass
+class SoundEffectConfig:
+    frequency: float = 5.0
+    depth: float = 1.0
+
+
+@dataclass
+class SoundConfig:
+    midi_scale: List[int] = field(
+        default_factory=lambda: list(range(60, 85))
+    )
+    note_indices: List[int] = field(
+        default_factory=lambda: [0, 2, 4, 5, 7, 9, 11, 12, 14, 16, 17, 19, 21, 23, 24]
+    )
+    detune_amount: float = 512.0
+    effect_frequency_amount: float = 16.0
+    harmonicity_amount: float = 16.0
+    modulation_amount: float = 64.0
+    volume_amount: float = 16.0
+    effect: SoundEffectConfig = field(default_factory=SoundEffectConfig)
+
+
+@dataclass
+class Ml5Config:
+    lips_close_threshold: float = 4.0
+    lips_open_threshold: float = 8.0
+    idle_volume_factor: float = 0.5
+    smoothness: float = 0.75
+    stroke_weight: float = 0.01
+    stroke_color: Tuple[int, int, int] = (255, 255, 255)
+    glowing_stroke_weight: float = 0.015
+    glowing_stroke_color: Tuple[int, int, int] = (255, 255, 255)
+    lips_size: float = 0.75
+    placeholder_faces_path: str | None = "assets/demo-faces.json"
+    blurriness: float = 0.0
+
+
+@dataclass
+class VideoConfig:
+    width: int = 480
+    height: int = 480
+    pixelation_short_side_num: int = 24
+    pixelation_style: int = 6
+    flipped: bool = True
+    background_color: Tuple[int, int, int] = (0, 0, 0)
+    overlay_color: Tuple[int, int, int, int] = (0, 0, 0, 100)
+    min_factor_size: float = 0.3
+    max_factor_size: float = 0.9
+
+
+@dataclass
+class UiMessages:
+    loading: str = "LOADING..."
+    welcome: str = "CLICK HERE TO ACTIVATE AUDIO"
+    running: str = ""
+
+
+@dataclass
+class UiConfig:
+    font_path: str = "assets/Ubuntu-Bold.ttf"
+    text_color: Tuple[int, int, int] = (255, 255, 255)
+    messages: UiMessages = field(default_factory=UiMessages)
+
+
+@dataclass
+class AppConfig:
+    fps: int = 60
+    exhibit: ExhibitConfig = field(default_factory=ExhibitConfig)
+    sound: SoundConfig = field(default_factory=SoundConfig)
+    ml5: Ml5Config = field(default_factory=Ml5Config)
+    video: VideoConfig = field(default_factory=VideoConfig)
+    ui: UiConfig = field(default_factory=UiConfig)

--- a/python_port/mouth_synth/face_tracker.py
+++ b/python_port/mouth_synth/face_tracker.py
@@ -1,0 +1,82 @@
+"""MediaPipe FaceMesh wrapper matching the JavaScript ml5 manager."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Optional
+
+import mediapipe as mp
+import numpy as np
+
+from .config import Ml5Config
+
+
+@dataclass
+class FaceMetrics:
+    lips_opening: float
+    lips_rotation: float
+    tip_heading_x: float
+    tip_heading_y: float
+
+
+class FaceTracker:
+    def __init__(self, config: Ml5Config) -> None:
+        self.config = config
+        self.mesh = mp.solutions.face_mesh.FaceMesh(
+            static_image_mode=False,
+            max_num_faces=1,
+            refine_landmarks=False,
+            min_detection_confidence=0.5,
+            min_tracking_confidence=0.5,
+        )
+        self._lips_open_samples: Deque[float] = deque(maxlen=5)
+        self._rotation_samples: Deque[float] = deque(maxlen=5)
+
+    def process(self, frame: np.ndarray) -> Optional[FaceMetrics]:
+        frame.flags.writeable = False
+        results = self.mesh.process(frame)
+        frame.flags.writeable = True
+        if not results.multi_face_landmarks:
+            return None
+
+        face_landmarks = results.multi_face_landmarks[0]
+        points = np.array([(lm.x, lm.y, lm.z) for lm in face_landmarks.landmark])
+
+        opening = self._compute_lip_opening(points)
+        rotation = self._compute_rotation(points)
+        tip_heading = self._compute_tip_heading(points)
+
+        self._lips_open_samples.append(opening)
+        self._rotation_samples.append(rotation)
+
+        return FaceMetrics(
+            lips_opening=np.mean(self._lips_open_samples),
+            lips_rotation=np.mean(self._rotation_samples),
+            tip_heading_x=tip_heading[0],
+            tip_heading_y=tip_heading[1],
+        )
+
+    def _compute_lip_opening(self, points: np.ndarray) -> float:
+        top_lip = points[13]  # upper lip landmark
+        bottom_lip = points[14]  # lower lip landmark
+        distance = np.linalg.norm(top_lip - bottom_lip)
+        return distance * 100  # scale for easier thresholds
+
+    def _compute_rotation(self, points: np.ndarray) -> float:
+        left_mouth = points[61]
+        right_mouth = points[291]
+        delta = right_mouth - left_mouth
+        return np.degrees(np.arctan2(delta[1], delta[0]))
+
+    def _compute_tip_heading(self, points: np.ndarray) -> np.ndarray:
+        tip = points[0]
+        nose = points[1]
+        vector = tip - nose
+        return vector[:2] * 100
+
+    def close(self) -> None:
+        self.mesh.close()
+
+
+__all__ = ["FaceTracker", "FaceMetrics"]

--- a/python_port/mouth_synth/sound.py
+++ b/python_port/mouth_synth/sound.py
@@ -1,0 +1,97 @@
+"""Simplified Tone.js-inspired synthesiser built on Pygame."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pygame
+
+from .config import SoundConfig
+
+
+@dataclass
+class SynthState:
+    frequency: float
+    modulation_index: float
+    harmonicity: float
+    volume: float
+
+
+class SoundManager:
+    def __init__(self, config: SoundConfig, sample_rate: int = 44100) -> None:
+        self.config = config
+        self.sample_rate = sample_rate
+        self.current_state = SynthState(
+            frequency=440.0,
+            modulation_index=10.0,
+            harmonicity=3.0,
+            volume=0.5,
+        )
+        self.channel: Optional[pygame.mixer.Channel] = None
+        pygame.mixer.pre_init(sample_rate=sample_rate, size=-16, channels=1)
+        pygame.mixer.init()
+
+    def trigger_start(self, rotation_pct: float) -> None:
+        note_idx = self._quantise_rotation(rotation_pct)
+        midi_note = self.config.midi_scale[self.config.note_indices[note_idx]]
+        frequency = 440.0 * (2 ** ((midi_note - 69) / 12))
+        self.current_state.frequency = frequency
+        self._play_tone()
+
+    def trigger_end(self) -> None:
+        if self.channel:
+            self.channel.fadeout(100)
+
+    def change_volume(self, opening_pct: float) -> None:
+        self.current_state.volume = max(0.05, min(1.0, opening_pct))
+        if self.channel:
+            self.channel.set_volume(self.current_state.volume)
+
+    def detune(self, rotation_pct: float) -> None:
+        detune_cents = (rotation_pct - 0.5) * self.config.detune_amount
+        self.current_state.frequency *= 2 ** (detune_cents / 1200)
+        self._play_tone()
+
+    def change_effect_frequency(self, rotation_pct: float) -> None:
+        self.current_state.modulation_index = 1 + rotation_pct * self.config.effect_frequency_amount
+        self._play_tone()
+
+    def move_harmonicity(self, heading_pct: float) -> None:
+        self.current_state.harmonicity = 1 + heading_pct * self.config.harmonicity_amount
+        self._play_tone()
+
+    def change_modulation_index(self, heading_pct: float) -> None:
+        self.current_state.modulation_index = 1 + heading_pct * self.config.modulation_amount
+        self._play_tone()
+
+    def _quantise_rotation(self, rotation_pct: float) -> int:
+        idx = int(rotation_pct * len(self.config.note_indices))
+        return max(0, min(len(self.config.note_indices) - 1, idx))
+
+    def _play_tone(self) -> None:
+        duration = 0.25
+        t = np.linspace(0, duration, int(self.sample_rate * duration), False)
+        modulator = np.sin(2 * np.pi * self.current_state.frequency * self.current_state.harmonicity * t)
+        carrier = np.sin(
+            2 * np.pi * self.current_state.frequency * t +
+            self.current_state.modulation_index * modulator
+        )
+        waveform = (carrier * self.current_state.volume).astype(np.float32)
+        sound = pygame.sndarray.make_sound((waveform * 32767).astype(np.int16))
+        if self.channel:
+            self.channel.stop()
+        self.channel = sound.play(-1)
+        if self.channel:
+            self.channel.set_volume(self.current_state.volume)
+
+    def get_waveform_values(self, samples: int = 128) -> np.ndarray:
+        t = np.linspace(0, 1, samples)
+        return np.sin(2 * np.pi * t)
+
+    def close(self) -> None:
+        pygame.mixer.quit()
+
+
+__all__ = ["SoundManager"]

--- a/python_port/mouth_synth/ui.py
+++ b/python_port/mouth_synth/ui.py
@@ -1,0 +1,47 @@
+"""UI rendering helpers for Pygame."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pygame
+
+from .config import UiConfig
+
+
+@dataclass
+class UiState:
+    message: str = ""
+    loading: bool = True
+    face_detected: bool = False
+
+
+class UiManager:
+    def __init__(self, config: UiConfig) -> None:
+        self.config = config
+        pygame.font.init()
+        try:
+            self.font = pygame.font.Font(self.config.font_path, 24)
+        except FileNotFoundError:
+            self.font = pygame.font.SysFont("Arial", 24)
+        self.state = UiState(message=self.config.messages.loading)
+
+    def update(self, ready: bool, audio_started: bool, face_detected: bool) -> None:
+        if not ready:
+            self.state = UiState(message=self.config.messages.loading, loading=True)
+        elif not audio_started:
+            self.state = UiState(message=self.config.messages.welcome, loading=False)
+        elif not face_detected:
+            self.state = UiState(message=self.config.messages.running or "NO FACE DETECTED", loading=False)
+        else:
+            self.state = UiState(message=self.config.messages.running, loading=False, face_detected=True)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        if not self.state.message:
+            return
+        text_surface = self.font.render(self.state.message, True, self.config.text_color)
+        rect = text_surface.get_rect(center=(surface.get_width() // 2, surface.get_height() - 50))
+        surface.blit(text_surface, rect)
+
+
+__all__ = ["UiManager"]

--- a/python_port/mouth_synth/video.py
+++ b/python_port/mouth_synth/video.py
@@ -1,0 +1,61 @@
+"""Video capture and drawing utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import cv2
+import numpy as np
+
+from .config import VideoConfig
+
+
+@dataclass
+class FrameBundle:
+    frame: np.ndarray
+    surface: np.ndarray
+
+
+class VideoManager:
+    """Wraps OpenCV capture with simple pixelation and mirroring."""
+
+    def __init__(self, config: VideoConfig) -> None:
+        self.config = config
+        self.capture = cv2.VideoCapture(0)
+        if not self.capture.isOpened():
+            raise RuntimeError("Could not open default webcam (index 0).")
+
+        self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, config.width)
+        self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, config.height)
+
+    def read(self) -> FrameBundle:
+        success, frame = self.capture.read()
+        if not success:
+            raise RuntimeError("Failed to read frame from webcam.")
+
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        if self.config.flipped:
+            frame = cv2.flip(frame, 1)
+
+        pixelated = self._pixelate(frame)
+        overlay = self._apply_overlay(pixelated)
+        return FrameBundle(frame=frame, surface=overlay)
+
+    def _pixelate(self, frame: np.ndarray) -> np.ndarray:
+        short_side = min(frame.shape[:2])
+        downscale = max(1, short_side // self.config.pixelation_short_side_num)
+        small = cv2.resize(frame, (frame.shape[1] // downscale, frame.shape[0] // downscale), interpolation=cv2.INTER_LINEAR)
+        return cv2.resize(small, (frame.shape[1], frame.shape[0]), interpolation=cv2.INTER_NEAREST)
+
+    def _apply_overlay(self, frame: np.ndarray) -> np.ndarray:
+        alpha = self.config.overlay_color[3] / 255.0
+        overlay_color = np.array(self.config.overlay_color[:3], dtype=frame.dtype)
+        blended = cv2.addWeighted(frame, 1 - alpha, overlay_color, alpha, 0)
+        return blended
+
+    def release(self) -> None:
+        self.capture.release()
+
+
+__all__ = ["VideoManager", "FrameBundle"]

--- a/python_port/pyproject.toml
+++ b/python_port/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mouth-synth"
+version = "0.1.0"
+description = "Realtime lip-controlled synthesiser using OpenCV, MediaPipe, and Pygame."
+readme = "README.md"
+authors = [{ name = "Mouth Synth Maintainers" }]
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dependencies = [
+  "opencv-python",
+  "mediapipe",
+  "numpy",
+  "pygame",
+  "sounddevice",
+]
+
+[project.scripts]
+mouth-synth = "mouth_synth.__main__:main"


### PR DESCRIPTION
## Summary
- add documentation summarizing the JavaScript project and the Python conversion plan
- introduce a python_port package that recreates the app with OpenCV, MediaPipe, and Pygame
- expose install instructions and entry points for running the Python version locally

## Testing
- python -m compileall python_port

------
https://chatgpt.com/codex/tasks/task_e_68d6353c717c832190cee315acb53be5